### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Build progress. All commands written in PowerShell syntax, Python version 3.11 i
 
 1. Grab sources from here, open PowerShell in this folder
 2. Install NodeJS dependencies: `npm i`
-3. Create virtualenv: `python3.11 -m venv`
+3. Create virtualenv: `python3.11 -m venv venv`
 4. Activate virtualenv: `.\venv\Scripts\activate`
 5. Install Python dependencies: `pip install -r requirements.txt`
 6. Try to build a binary package with script: `python make_release.py`
@@ -122,7 +122,7 @@ Build progress.
 
 1. Grab sources from here, open terminal in this folder
 2. Install NodeJS dependencies: `npm i`
-3. Create virtualenv: `python3.11 -m venv`
+3. Create virtualenv: `python3.11 -m venv venv`
 4. Activate virtualenv: `source venv/bin/activate`
 5. Install Python dependencies: `pip install -r requirements.txt`
 6. Try to build a binary package with script: `python make_release.py`

--- a/zp_server/main.py
+++ b/zp_server/main.py
@@ -36,7 +36,7 @@ def main():
 
     # Tray menu
     import pystray
-    State.applet = pystray.Icon("ZeppPLayer",
+    State.applet = pystray.Icon("ZeppPlayer",
                                 icon=Image.open(ROOT_DIR / "app" / "icon.png"),
                                 menu=build_menu())
 

--- a/zp_server/server_data.py
+++ b/zp_server/server_data.py
@@ -10,11 +10,11 @@ if hasattr(sys, "frozen"):
         ROOT_DIR = ROOT_DIR.parent / "Resources"
 
 if sys.platform == "win32":
-    CONFIG_DIR = Path.home() / "AppData/Roaming/ZeppPLayer"
+    CONFIG_DIR = Path.home() / "AppData/Roaming/ZeppPlayer"
 elif sys.platform == "darwin":
-    CONFIG_DIR = Path.home() / "Library/Application Support/ZeppPLayer"
+    CONFIG_DIR = Path.home() / "Library/Application Support/ZeppPlayer"
 else:
-    CONFIG_DIR = Path.home() / ".config/ZeppPLayer"
+    CONFIG_DIR = Path.home() / ".config/ZeppPlayer"
 
 PROJECTS_DIR = ROOT_DIR / "projects"
 


### PR DESCRIPTION
- In README.md, the `python3.11 -m venv` command is missing an argument (`ENV_DIR`).
- The application directory is spelled `ZeppPLayer` instead of `ZeppPlayer` (uppercase `L`).