### PR TITLE
Add support for hmUI.prop.LEVEL

### DIFF
--- a/src/zepp_player/ui/HuamiUI.js
+++ b/src/zepp_player/ui/HuamiUI.js
@@ -201,6 +201,7 @@ export default class HuamiUIMock {
         TEXT: "text",
         TEXT_SIZE: "text_size",
         COLOR: "color",
+        LEVEL: "level",
         RADIUS: "radius",
         START_ANGLE: "start_angle",
         END_ANGLE: "end_angle",


### PR DESCRIPTION
This adds `LEVEL: "level"` to the `HuamiUIMock` class, allowing `setProperty(hmUI.prop.LEVEL, ...)` to change the level of an `ARC_PROGRESS`. (I already confirmed that this works on my Xiaomi Smart Band 7.)